### PR TITLE
944 Fixes for BCRHP Landing Page

### DIFF
--- a/src/bcrhp/bcrhp/media/css/index-slider.css
+++ b/src/bcrhp/bcrhp/media/css/index-slider.css
@@ -127,18 +127,13 @@
         /*height: 7vh;*/
         /*width: 7vh;*/
     }
+
     .app-info-block.intro-section h2 {
         font-size: 2rem;
     }
-    
+
     .bc-splash-caption > h3 {
         font-size: 1.1rem;
-    }
-
-
-
-    #info-block-1 {
-        padding-top: 0;
     }
 }
 

--- a/src/bcrhp/bcrhp/templates/index.htm
+++ b/src/bcrhp/bcrhp/templates/index.htm
@@ -46,16 +46,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     <link href="{% webpack_static 'css/fontawesome/css/fontawesome.min.css' %}" rel="stylesheet">
     <link href="{% webpack_static 'css/fontawesome/css/solid.min.css' %}" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="{% webpack_static 'plugins/slick/slick.min.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% webpack_static 'plugins/slick/accessible-slick-theme.min.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% webpack_static 'css/index.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% webpack_static 'css/index-slider.css' %}">
     <link href="{% webpack_static 'css/index.css' %}" rel="stylesheet">
     <link href="{% webpack_static 'css/project.css' %}" rel="stylesheet">
     <link href="{% webpack_static 'css/bc_index.css' %}" rel="stylesheet">
     {% if app_settings.ACCESSIBILITY_MODE %}
     <link href="{% webpack_static 'css/accessibility.css' %}" rel="stylesheet">
     {% endif %}
-    <link rel="stylesheet" type="text/css" href="{% webpack_static 'plugins/slick/slick.min.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% webpack_static 'plugins/slick/accessible-slick-theme.min.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% webpack_static 'css/index.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% webpack_static 'css/index-slider.css' %}">
 </head>
 
 <body>

--- a/src/common/media/css/bc_index.css
+++ b/src/common/media/css/bc_index.css
@@ -10,7 +10,6 @@
 
 .app-info-manual-item img {
     width: 100%;
-    max-width: 200px;
     height: auto;
 }
 


### PR DESCRIPTION
bcgov/BCHeritage#944

- Reorder css for this project styling to be taken instead of arches generated index styling
- Removed rule for reducing padding on the top block info elements
- Removed max-width for the manual images to look centred on various displays