### PR TITLE
967 - Conditions added to hide detail sections for internal users

### DIFF
--- a/src/bcrhp/bcrhp/media/js/viewmodels/bcrhp-site.js
+++ b/src/bcrhp/bcrhp/media/js/viewmodels/bcrhp-site.js
@@ -172,6 +172,24 @@ define([
 
         this.actAuthorities = {};
 
+        this.getUser = function() {
+            let user = ko.mapping.fromJS({"username":"","first_name":"","last_name":"","groups":[]});
+            $.ajax({
+                url: `${self.urls.root}user_profile`
+            }).done(function (data) {
+                if (data)
+                {
+                    ko.mapping.fromJS(data, user);
+                }
+            });
+            return user;
+        };
+        this.user = this.getUser();
+
+        this.isAnonymous = ko.computed( function() {
+            return ko.unwrap(this.user.username) === 'anonymous';
+        }, this);
+
         this.getLegislativeAct = function (relatedActObject) {
             let actId = ko.unwrap(ko.unwrap(relatedActObject)[0].resourceId);
             if (!!actId && this.actAuthorities[actId])

--- a/src/bcrhp/bcrhp/releases/1.1.0.md
+++ b/src/bcrhp/bcrhp/releases/1.1.0.md
@@ -5,6 +5,7 @@ This release implements changes to support deployment to the public
 
 # Bug fixes and enhancements
 - 636 - Update site search card attributes
+- 967 - Conditions added to hide detail sections for internal users
 - 944 -
 - 947 - Public Site CSV output
   - Introduces changes for single view for including resource tile data for DataBC and Heritage Site CSV Export

--- a/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
+++ b/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
@@ -136,7 +136,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'borden_number_section', sectionController: bordenNumberVisible} -->
     <span class="rp-tile-title">Site ID Number</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -274,7 +274,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'chronology_section', sectionController: chronologyVisible} -->
     <span class="rp-tile-title">Chronology</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -307,7 +307,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'sos_section', sectionController: sosVisible} -->
     <span class="rp-tile-title">Statement of Significance</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -368,7 +368,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'heritage_class_section', sectionController: heritageClassVisible} -->
     <span class="rp-tile-title">Heritage Class</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -421,7 +421,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'heritage_function_section', sectionController: heritageFunctionVisible} -->
     <span class="rp-tile-title">Heritage Function</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -466,7 +466,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'heritage_theme_section', sectionController: heritageThemeVisible} -->
     <span class="rp-tile-title">Heritage Theme</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},

--- a/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
+++ b/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
@@ -61,7 +61,7 @@
     <!-- /ko -->
     <!-- /ko -->
 </div>
-<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
+<div class="rp-card-section" data-bind="css: {'hide-section': !isAnonymous()}">
     <!-- ko let: {targetSection: 'site_name_section', sectionController: siteNamesVisible} -->
     <span class="rp-tile-title">Site Name</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},

--- a/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
+++ b/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
@@ -61,8 +61,7 @@
     <!-- /ko -->
     <!-- /ko -->
 </div>
-
-<div class="rp-card-section ">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'site_name_section', sectionController: siteNamesVisible} -->
     <span class="rp-tile-title">Site Name</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -137,7 +136,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'borden_number_section', sectionController: bordenNumberVisible} -->
     <span class="rp-tile-title">Site ID Number</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -275,7 +274,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'chronology_section', sectionController: chronologyVisible} -->
     <span class="rp-tile-title">Chronology</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -308,7 +307,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'sos_section', sectionController: sosVisible} -->
     <span class="rp-tile-title">Statement of Significance</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -369,7 +368,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'heritage_class_section', sectionController: heritageClassVisible} -->
     <span class="rp-tile-title">Heritage Class</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -422,7 +421,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'heritage_function_section', sectionController: heritageFunctionVisible} -->
     <span class="rp-tile-title">Heritage Function</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},
@@ -467,7 +466,7 @@
     <!-- /ko -->
 </div>
 
-<div class="rp-card-section">
+<div class="rp-card-section {% if user.username != 'anonymous' %}hide-section{% endif %}">
     <!-- ko let: {targetSection: 'heritage_theme_section', sectionController: heritageThemeVisible} -->
     <span class="rp-tile-title">Heritage Theme</span>
     <i class="fa report-expander print-hide fa-angle-down" tabindex="0" role="button" data-target="site_name_section" data-bind="onEnterkeyClick, onSpaceClick, let: {sectionController: siteNamesVisible, targetSection: 'site_name_section'},

--- a/src/bcrhp/bcrhp/views/api.py
+++ b/src/bcrhp/bcrhp/views/api.py
@@ -2,6 +2,7 @@ import logging
 from arches.app.views.api import APIBase
 from django.http import HttpResponse
 
+from arches.app.models import models
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 from arches.app.utils.response import JSONResponse
@@ -32,6 +33,18 @@ class LegislativeAct(APIBase):
         act = legislative_act_proxy.get_authorities(act_id)
         # print("Scientific Names: %s" % names)
         return JSONResponse(JSONSerializer().serializeToPython(act))
+
+
+class UserProfile(APIBase):
+    def get(self, request):
+        user_profile = models.User.objects.get(id=request.user.pk)
+        group_names = [group.name for group in models.Group.objects.filter(user=user_profile).all()]
+        return JSONResponse(JSONSerializer().serializeToPython(
+            {"username": user_profile.username,
+             "first_name": user_profile.first_name,
+             "last_name": user_profile.last_name,
+             "groups": group_names}
+        ))
 
 
 query_config = {

--- a/src/common/media/css/project_common.css
+++ b/src/common/media/css/project_common.css
@@ -101,6 +101,10 @@ table.bc-summary-table td {
     display: inline-block;
 }
 
+.hide-section {
+    display: none;
+}
+
 .grid-col-1 {
     grid-column-start: 1;
 }

--- a/src/common/media/css/project_common.css
+++ b/src/common/media/css/project_common.css
@@ -380,6 +380,10 @@ img.bc-details-image
         display: none !important;
     }
 
+    .hide-section {
+        display: block;
+    }
+
     /* Align the date on the RHS next to the name of the site*/
     .ep-form-toolbar-tools {
         float: right !important;


### PR DESCRIPTION
bcgov/BCHeritage#967

Also includes a requirement for bcgov/BCHeritage#948 to show the hidden sections on print for internal users.

Implementation notes:
1. Added an API endpoint to get the currently authenticated (or anonymous user)
2. Added an `isAnonymous` function that checks if the username is `anonymous`
3. Sections in the details page are hidden if `!isAnonymous()`