### PR TITLE
948 - Improvements for print the site details page

### DIFF
--- a/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
+++ b/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site_public.htm
@@ -1,5 +1,9 @@
 <div class="details-card-section">
-<div style="display: flex;justify-content:right;padding:1em 0">
+<div class="details-icons">
+    <a data-bind="click: function () { window.print() }" style="cursor:pointer;">
+        <span>Print</span>
+        <i class="fa fa-print"></i>
+    </a>
     <a data-bind="click: function () { helpactive(true) }" style="cursor:pointer;">
         <span data-bind="text: $root.translations.help"></span>
         <i class="fa fa-question-circle"></i>

--- a/src/common/media/css/project_common.css
+++ b/src/common/media/css/project_common.css
@@ -185,6 +185,13 @@ table.bc-summary-table td {
     justify-content: left;
 }
 
+.details-icons {
+    display: flex;
+    gap: 12px;
+    justify-content: right;
+    padding: 14px 0;
+}
+
 .details-card-section .dl-horizontal dt {
     width: 200px;
     overflow: visible !important;
@@ -375,13 +382,19 @@ img.bc-details-image
     /*    height: 99%;*/
     /*}*/
 
-    /* Hide unwanted parts of the page */
-    section.search-results-panel, .search-toolbar, #skip-link-holder {
+    /* From arches but doesn't set it to important */
+    .print-hide {
         display: none !important;
+        height: 0 !important;
     }
 
     .hide-section {
         display: block;
+    }
+
+    /* Hide unwanted parts of the page */
+    section.search-results-panel, .search-toolbar, #skip-link-holder {
+        display: none !important;
     }
 
     /* Align the date on the RHS next to the name of the site*/
@@ -451,4 +464,54 @@ img.bc-details-image
         display: block !important;
     }
 
+    .details-icons {
+        display: none;
+    }
+
+    dt {
+        color: black !important;
+        text-decoration: none;
+    }
+
+    /* For displaying long-form text blocks as full width of the page,
+     * some elements are within components and not easy to modify but do have
+     * an id that can be queried.
+     */
+    dd[data-bind*="addressPart"],
+    dd[data-bind*="physical_description"],
+    dd[data-bind*="heritage_value"],
+    dd[data-bind*="defining_elements"] {
+        width: auto !important;
+    }
+
+    /* Example in case need to do something with the older sibling
+    dt:has(+ dd[data-bind*="physical_description"]) {
+        color: black !important;
+    }
+    */
+
+    .data-carousel {
+        max-width: 100vw !important;
+    }
+
+    .data-carousel button,
+    .data-carousel .slick-dots {
+        display: none !important;
+    }
+
+    .data-carousel .slick-track {
+        display: flex;
+        transform: unset !important;
+        width: 100% !important;
+        justify-content: center;
+    }
+
+    .data-carousel .slick-slide {
+        display: none !important;
+    }
+
+    .data-carousel .slick-slide:first-child {
+        display: block !important;
+        float: none !important;
+    }
 }


### PR DESCRIPTION
Fixes need for:
- [ ] Avoiding large chunks of whitespace; premature page breaks in-between sections
- [ ] Remove lines that don't have a value