### PR TITLE
948 - Fixed bcrhp heritage details print display for sos section

### DIFF
--- a/src/common/media/css/project_common.css
+++ b/src/common/media/css/project_common.css
@@ -468,9 +468,17 @@ img.bc-details-image
         display: none;
     }
 
+    #sos_section > div {
+        display: block !important;
+    }
+
     dt {
         color: black !important;
         text-decoration: none;
+    }
+
+    dd {
+        clear: none !important;
     }
 
     /* For displaying long-form text blocks as full width of the page,
@@ -482,13 +490,8 @@ img.bc-details-image
     dd[data-bind*="heritage_value"],
     dd[data-bind*="defining_elements"] {
         width: auto !important;
+        display: block !important;
     }
-
-    /* Example in case need to do something with the older sibling
-    dt:has(+ dd[data-bind*="physical_description"]) {
-        color: black !important;
-    }
-    */
 
     .data-carousel {
         max-width: 100vw !important;


### PR DESCRIPTION
The section was prematurely breaking due to the set display inline-flex, for the browser to break appropriately within the section, its display needs to be set to block.

To prevent the browser clipping text between pages, the clear property needs to be set to none and the display property set to block.