### PR TITLE
1025 - Fixed carousel css modifications over-reaching to bcrhp landing page

### DIFF
--- a/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site.htm
+++ b/src/bcrhp/bcrhp/templates/views/report-templates/details/heritage_site.htm
@@ -9,7 +9,7 @@
         <i class="fa fa-question-circle"></i>
     </a>
 </div>
-<div class="data-carousel summary-slider" data-bind="descendantsComplete: initCarousel, visible: nodesHaveData(['site_images'])" style="background-color:#f2f2f2;max-width: calc(100vw - 600px);padding:1em">
+<div class="data-carousel summary-slider details-site-images" data-bind="descendantsComplete: initCarousel, visible: nodesHaveData(['site_images'])" style="background-color:#f2f2f2;max-width: calc(100vw - 600px);padding:1em">
     <!-- ko let: {widget: getWidgetForAlias('image_date')}-->
     <!-- ko foreach: { data: getValuesFromTiles(['site_images', 'image_type', 'image_features', 'image_view', 'image_date', 'copyright', 'photographer']), as: 'tileValues' } -->
     <div class="details-carousel">

--- a/src/common/media/css/bc_index.css
+++ b/src/common/media/css/bc_index.css
@@ -114,6 +114,15 @@ li.app-info-block-text {
     }
 }
 
+@media only screen and (max-width: 768px) {
+    .app-info-block {
+        padding: 20px 10px;
+    }
+    .app-info-block.intro-section {
+        padding: 0;
+    }
+}
+
 @media only screen and (min-width: 768px) {
     .bc-splash-caption {
         min-width: 80vw !important;

--- a/src/common/media/css/project_common.css
+++ b/src/common/media/css/project_common.css
@@ -353,40 +353,40 @@ img.bc-details-image
 }
 
 @media only screen and (max-width: 1024px) {
-    .data-carousel {
+    .data-carousel.details-site-images {
         max-width: 100% !important;
     }
 
-    .slick-arrow {
+    .details-site-images .slick-arrow {
         background: rgba(255,255,255,0.8) !important;
         border-radius: 100%;
         height: 40px !important;
         width: 40px !important;
     }
 
-    .slick-next {
+    .details-site-images .slick-next {
         right: 8px !important;
     }
 
-    .slick-prev {
+    .details-site-images .slick-prev {
         left: 8px !important;
     }
 
-    .slick-slide {
+    .details-site-images .slick-slide {
         max-width: 80vw;
     }
 
-    .slick-slide img {
+    .details-site-images .slick-slide img {
         align-self: center;
         height: auto !important;
         max-width: 80vw;
     }
 
-    .slick-slide .photo-info {
+    .details-site-images .slick-slide .photo-info {
         align-self: end;
     }
 
-    .details-carousel {
+    .details-site-images .details-carousel {
         display: grid !important;
         grid-template-rows: 4fr 1fr;
         justify-items: center;


### PR DESCRIPTION
These rules are specifically for the mobile viewing on the bcrhp details tab for heritage sites and wasn't expecting to cause issue with the carousel used on the landing page